### PR TITLE
Использование типа String вместо UUID для primaryKey и мастеровых связей.

### DIFF
--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/FavoriteFeature.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/FavoriteFeature.java
@@ -1,6 +1,7 @@
 package Flexberry.GIS.model;
 
 import Flexberry.GIS.utils.UUIDConverter;
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
 
@@ -8,7 +9,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.util.Date;
 import java.util.UUID;
 
 @Entity(name = "FavoriteFeature")
@@ -16,10 +16,10 @@ import java.util.UUID;
 public class FavoriteFeature {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "CreateTime", nullable = true)
     private java.sql.Timestamp createTime;
@@ -50,11 +50,11 @@ public class FavoriteFeature {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/FlexberryAdvLimit.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/FlexberryAdvLimit.java
@@ -1,11 +1,10 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 /**
  * Entity implementation class for Entity: FlexberryAdvLimit
@@ -15,10 +14,10 @@ import java.util.UUID;
 public class FlexberryAdvLimit {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 	
 	@Column(name = "User", nullable = true, length = 255)
     private String user;
@@ -39,11 +38,11 @@ public class FlexberryAdvLimit {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 	

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/IISCaseberryLoggingObjectsApplicationLog.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/IISCaseberryLoggingObjectsApplicationLog.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
 import java.util.Date;
-import java.util.UUID;
 
 /**
  * Entity implementation class for Entity: IISCaseberryLoggingObjectsApplicationLog
@@ -16,10 +15,10 @@ import java.util.UUID;
 public class IISCaseberryLoggingObjectsApplicationLog {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "Category", nullable = true, length = 64)
     private String category;
@@ -67,11 +66,11 @@ public class IISCaseberryLoggingObjectsApplicationLog {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LayerLink.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LayerLink.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 import java.util.List;
 
@@ -18,29 +17,29 @@ import java.util.List;
 public class LayerLink {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "AllowShow")
     private Boolean allowShow;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "MapObjectSetting")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "MapObjectSetting")
     @Convert("MapObjectSetting")
-    @Column(name = "MapObjectSetting", length = 16, unique = true, nullable = false)
-    private UUID _mapobjectsettingid;
+    @Column(name = "MapObjectSetting", unique = true, nullable = false)
+    private String _mapobjectsettingid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "MapObjectSetting", insertable = false, updatable = false)
     private MapObjectSetting mapObjectSetting;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "Layer")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "Layer")
     @Convert("Layer")
-    @Column(name = "Layer", length = 16, unique = true, nullable = false)
-    private UUID _layerid;
+    @Column(name = "Layer", unique = true, nullable = false)
+    private String _layerid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "Layer", insertable = false, updatable = false)
@@ -53,11 +52,11 @@ public class LayerLink {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 
@@ -67,6 +66,30 @@ public class LayerLink {
 
     public void setAllowShow(Boolean allowshow) {
       this.allowShow = allowshow;
+    }
+
+    public MapObjectSetting getMapObjectSetting() {
+        return mapObjectSetting;
+    }
+
+    public void setMapObjectSetting(MapObjectSetting mapObjectSetting) {
+        this.mapObjectSetting = mapObjectSetting;
+
+        if (mapObjectSetting != null) {
+            this._mapobjectsettingid = mapObjectSetting.getPrimarykey();
+        }
+    }
+
+    public MapLayer getLayer() {
+        return layer;
+    }
+
+    public void setLayer(MapLayer layer) {
+        this.layer = layer;
+
+        if (layer != null) {
+            this._layerid = layer.getPrimarykey();
+        }
     }
 
     public List<LinkParameter> getParameters() {

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LayerMetadata.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LayerMetadata.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
 import Flexberry.GIS.utils.PGgeometryConverter;
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 import java.util.List;
 
@@ -18,10 +17,10 @@ import java.util.List;
 public class LayerMetadata {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "Name", length = 255)
     private String name;
@@ -75,11 +74,11 @@ public class LayerMetadata {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LinkMetadata.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LinkMetadata.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 import java.util.List;
 
@@ -18,10 +17,10 @@ import java.util.List;
 public class LinkMetadata {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "AllowShow")
     private Boolean allowShow;
@@ -39,20 +38,20 @@ public class LinkMetadata {
     private String editor;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "MapObjectSetting")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "MapObjectSetting")
     @Convert("MapObjectSetting")
-    @Column(name = "MapObjectSetting", length = 16, unique = true, nullable = false)
-    private UUID _mapobjectsettingid;
+    @Column(name = "MapObjectSetting", unique = true, nullable = false)
+    private String _mapobjectsettingid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "MapObjectSetting", insertable = false, updatable = false)
     private MapObjectSetting mapobjectsetting;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "Layer")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "Layer")
     @Convert("Layer")
-    @Column(name = "Layer", length = 16, unique = true, nullable = false)
-    private UUID _layerid;
+    @Column(name = "Layer", unique = true, nullable = false)
+    private String _layerid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "Layer", insertable = false, updatable = false)
@@ -66,11 +65,11 @@ public class LinkMetadata {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 
@@ -114,5 +113,27 @@ public class LinkMetadata {
       this.editor = editor;
     }
 
+    public MapObjectSetting getMapObjectSetting() {
+        return mapobjectsetting;
+    }
 
+    public void setMapObjectSetting(MapObjectSetting mapObjectSetting) {
+        this.mapobjectsetting = mapObjectSetting;
+
+        if (mapObjectSetting != null) {
+            this._mapobjectsettingid = mapobjectsetting.getPrimarykey();
+        }
+    }
+
+    public LayerMetadata getLayer() {
+        return layer;
+    }
+
+    public void setLayer(LayerMetadata layer) {
+        this.layer = layer;
+
+        if (layer != null) {
+            this._layerid = layer.getPrimarykey();
+        }
+    }
 }

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LinkParameter.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/LinkParameter.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 /**
  * Entity implementation class for Entity: LinkParameter
@@ -16,10 +15,10 @@ import java.util.UUID;
 public class LinkParameter {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "ObjectField", length = 255)
     private String objectField;
@@ -37,10 +36,10 @@ public class LinkParameter {
     private Boolean linkField;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "LayerLink")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "LayerLink")
     @Convert("LayerLink")
-    @Column(name = "LayerLink", length = 16, unique = true, nullable = false)
-    private UUID _layerlinkid;
+    @Column(name = "LayerLink", unique = true, nullable = false)
+    private String _layerlinkid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "LayerLink", insertable = false, updatable = false)
@@ -51,11 +50,11 @@ public class LinkParameter {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 
@@ -99,5 +98,15 @@ public class LinkParameter {
       this.linkField = linkfield;
     }
 
+    public LayerLink getLayerLink() {
+        return layerLink;
+    }
 
+    public void setLayerLink(LayerLink layerLink) {
+        this.layerLink = layerLink;
+
+        if (layerLink != null) {
+            this._layerlinkid = layerLink.getPrimarykey();
+        }
+    }
 }

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/Map.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/Map.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
 import Flexberry.GIS.utils.PGgeometryConverter;
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 import java.util.List;
 
@@ -18,10 +17,10 @@ import java.util.List;
 public class Map {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "CreateTime")
     private java.sql.Timestamp createTime;
@@ -87,11 +86,11 @@ public class Map {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/MapLayer.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/MapLayer.java
@@ -85,7 +85,7 @@ public class MapLayer {
     @Column(name = "Parent", unique = true, nullable = false)
     private String _parentid;
 
-    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ManyToOne(optional = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "Parent", insertable = false, updatable = false)
     private MapLayer parent;
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/MapLayer.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/MapLayer.java
@@ -1,13 +1,12 @@
 package Flexberry.GIS.model;
 
 import Flexberry.GIS.utils.PGgeometryConverter;
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 import java.util.List;
 
@@ -19,10 +18,10 @@ import java.util.List;
 public class MapLayer {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "Name", length = 255)
     private String name;
@@ -81,20 +80,20 @@ public class MapLayer {
     private String editor;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "Parent")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "Parent")
     @Convert("Parent")
-    @Column(name = "Parent", length = 16, unique = true, nullable = false)
-    private UUID _parentid;
+    @Column(name = "Parent", unique = true, nullable = false)
+    private String _parentid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "Parent", insertable = false, updatable = false)
     private MapLayer parent;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "Map")
-    @Convert("Map")
-    @Column(name = "Map", length = 16, unique = true, nullable = false)
-    private UUID _mapid;
+    @Converter(converterClass = UUIDToStringConverter.class, name = "MapID")
+    @Convert("MapID")
+    @Column(name = "Map", unique = true, nullable = false)
+    private String _mapid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "Map", insertable = false, updatable = false)
@@ -107,11 +106,11 @@ public class MapLayer {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 
@@ -259,12 +258,28 @@ public class MapLayer {
       this.editor = editor;
     }
 
+    public MapLayer getParent() {
+        return parent;
+    }
+
+    public void setParent(MapLayer parent) {
+        this.parent = parent;
+
+        if (parent != null) {
+            this._parentid = parent.getPrimarykey();
+        }
+    }
+
     public Map getMap() {
         return map;
     }
 
     public void setMap(Map map) {
         this.map = map;
+
+        if (map != null) {
+            this._mapid = map.getPrimarykey();
+        }
     }
 
     public List<LayerLink> getLayerLink() {

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/MapObjectSetting.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/MapObjectSetting.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 /**
  * Entity implementation class for Entity: MapObjectSetting
@@ -16,10 +15,10 @@ import java.util.UUID;
 public class MapObjectSetting {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "TypeName", length = 255)
     private String typeName;
@@ -36,11 +35,23 @@ public class MapObjectSetting {
     @Column(name = "MultEditForm", length = 255)
     private String multEditForm;
 
+    @Column(name = "CreateTime")
+    private java.sql.Timestamp createTime;
+
+    @Column(name = "Creator", length = 255)
+    private String creator;
+
+    @Column(name = "EditTime")
+    private java.sql.Timestamp editTime;
+
+    @Column(name = "Editor", length = 255)
+    private String editor;
+
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "DefaultMap")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "DefaultMap")
     @Convert("DefaultMap")
-    @Column(name = "DefaultMap", length = 16, unique = true, nullable = false)
-    private UUID _defaultmapid;
+    @Column(name = "DefaultMap", unique = true, nullable = false)
+    private String _defaultmapid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "DefaultMap", insertable = false, updatable = false)
@@ -51,11 +62,11 @@ public class MapObjectSetting {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 
@@ -99,5 +110,47 @@ public class MapObjectSetting {
       this.multEditForm = multeditform;
     }
 
+    public java.sql.Timestamp getCreateTime() {
+        return createTime;
+    }
 
+    public void setCreateTime(java.sql.Timestamp createtime) {
+        this.createTime = createtime;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    public java.sql.Timestamp getEditTime() {
+        return editTime;
+    }
+
+    public void setEditTime(java.sql.Timestamp edittime) {
+        this.editTime = edittime;
+    }
+
+    public String getEditor() {
+        return editor;
+    }
+
+    public void setEditor(String editor) {
+        this.editor = editor;
+    }
+
+    public Map getDefaultMap() {
+        return defaultMap;
+    }
+
+    public void setDefaultMap(Map defaultMap) {
+        this.defaultMap = defaultMap;
+
+        if (defaultMap != null) {
+            this._defaultmapid = defaultMap.getPrimarykey();
+        }
+    }
 }

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/NewPlatformFlexberryFlexberryUserSetting.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/NewPlatformFlexberryFlexberryUserSetting.java
@@ -1,5 +1,6 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
 import Flexberry.GIS.utils.UUIDConverter;
@@ -16,10 +17,10 @@ import java.util.UUID;
 public class NewPlatformFlexberryFlexberryUserSetting {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "AppName", nullable = true, length = 256)
     private String appName;
@@ -78,11 +79,11 @@ public class NewPlatformFlexberryFlexberryUserSetting {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/ParameterMetadata.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/model/ParameterMetadata.java
@@ -1,12 +1,11 @@
 package Flexberry.GIS.model;
 
+import Flexberry.GIS.utils.UUIDToStringConverter;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.Converter;
-import Flexberry.GIS.utils.UUIDConverter;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 /**
  * Entity implementation class for Entity: ParameterMetadata
@@ -16,10 +15,10 @@ import java.util.UUID;
 public class ParameterMetadata {
 
     @Id
-    @Converter(converterClass = UUIDConverter.class, name = "primarykey")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "primarykey")
     @Convert("primarykey")
-    @Column(name = "primarykey", length = 16, unique = true, nullable = false)
-    private UUID primarykey;
+    @Column(name = "primarykey", unique = true, nullable = false)
+    private String primarykey;
 
     @Column(name = "ObjectField", length = 255)
     private String objectField;
@@ -49,10 +48,10 @@ public class ParameterMetadata {
     private String editor;
 
     @EdmIgnore
-    @Converter(converterClass = UUIDConverter.class, name = "LayerLink")
+    @Converter(converterClass = UUIDToStringConverter.class, name = "LayerLink")
     @Convert("LayerLink")
-    @Column(name = "LayerLink", length = 16, unique = true, nullable = false)
-    private UUID _layerlinkid;
+    @Column(name = "LayerLink", unique = true, nullable = false)
+    private String _layerlinkid;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "LayerLink", insertable = false, updatable = false)
@@ -63,11 +62,11 @@ public class ParameterMetadata {
         super();
     }
 
-    public void setPrimarykey(UUID primarykey) {
+    public void setPrimarykey(String primarykey) {
         this.primarykey = primarykey;
     }
 
-    public UUID getPrimarykey() {
+    public String getPrimarykey() {
         return primarykey;
     }
 
@@ -143,5 +142,15 @@ public class ParameterMetadata {
       this.editor = editor;
     }
 
+    public LinkMetadata getLayerLink() {
+        return layerLink;
+    }
 
+    public void setLayerLink(LinkMetadata layerLink) {
+        this.layerLink = layerLink;
+
+        if (layerLink != null) {
+            this._layerlinkid = layerLink.getPrimarykey();
+        }
+    }
 }

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpFilter.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpFilter.java
@@ -33,12 +33,14 @@ public class MutableHttpFilter implements javax.servlet.Filter {
         mutableRequest.replaceSubstringInBody("__PrimaryKey", "Primarykey");
         mutableRequest.replaceSubstringInBody("+eq+", " eq ");
 
+        mutableRequest.fixPrimaryKeyValuesInBody();
+
         HttpServletResponse resp = (HttpServletResponse) response;
         MutableHttpResponse mutableResponse = new MutableHttpResponse(resp);
 
         mutableResponse.setHeader("Access-Control-Allow-Origin", req.getHeader("Origin"));
         mutableResponse.setHeader("Access-Control-Allow-Credentials", "true");
-        mutableResponse.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        mutableResponse.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PATCH");
         mutableResponse.setHeader("Access-Control-Max-Age", "3600");
         mutableResponse.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me, OData-Version, Prefer");
 

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpFilter.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpFilter.java
@@ -33,7 +33,7 @@ public class MutableHttpFilter implements javax.servlet.Filter {
         mutableRequest.replaceSubstringInBody("__PrimaryKey", "Primarykey");
         mutableRequest.replaceSubstringInBody("+eq+", " eq ");
 
-        mutableRequest.fixPrimaryKeyValuesInBody();
+        mutableRequest.ApplyChangesForRequest();
 
         HttpServletResponse resp = (HttpServletResponse) response;
         MutableHttpResponse mutableResponse = new MutableHttpResponse(resp);

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpRequest.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpRequest.java
@@ -1,9 +1,13 @@
 package Flexberry.GIS.service;
 
-import org.json.JSONArray;
+import Flexberry.GIS.utils.batch.BatchRequest;
+;
+import Flexberry.GIS.utils.batch.BatchRequestPart;
+import Flexberry.GIS.utils.batch.BatchSubRequest;
 import org.json.JSONObject;
 
 import java.io.*;
+import java.text.ParseException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,22 +18,51 @@ import javax.servlet.http.HttpServletRequestWrapper;
 public class MutableHttpRequest extends HttpServletRequestWrapper {
     private String body;
     private List<String> excessHeaders;
-    private Map<String,String> replacedQuerySubstrings;
-
+    private Map<String, String> replacedQuerySubstrings;
+    private Map<String, String> replacedBodySubstrings;
     private List<String> existedEntities;
+
+    private Boolean isBatchRequest = false;
+    private String batchBoundaryId = null;
+    BatchRequest batchRequest = null;
 
     public MutableHttpRequest(HttpServletRequest request) throws IOException {
         super(request);
 
         excessHeaders = new ArrayList<String>();
+        existedEntities = new ArrayList<String>();
         replacedQuerySubstrings = new HashMap<String,String>();
+        replacedBodySubstrings = new HashMap<String,String>();
 
         catchRequestBody(request);
+
+        String currentUrl = request.getRequestURL().toString();
+
+        // batch запрос.
+        if (currentUrl.endsWith("$batch")) {
+            batchBoundaryId = getBatchBoundary(request);
+
+            if (batchBoundaryId != null) {
+                try {
+                    batchRequest = new BatchRequest(currentUrl, body, batchBoundaryId);
+                } catch (ParseException e) {
+                    throw new RuntimeException(e);
+                }
+
+                isBatchRequest = true;
+            }
+        }
     }
 
     @Override
     public ServletInputStream getInputStream() throws IOException {
-        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(body.getBytes());
+        String thisBody = body;
+
+        if (isBatchRequest) {
+            thisBody = batchRequest.toString();
+        }
+
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(thisBody.getBytes());
         ServletInputStream servletInputStream = new ServletInputStream() {
             public int read() throws IOException {
                 return byteArrayInputStream.read();
@@ -80,19 +113,22 @@ public class MutableHttpRequest extends HttpServletRequestWrapper {
     }
 
     public void replaceSubstringInBody(String originSubstring, String finalSubstring) {
-        body = convertGISJsonValuesToString(body);
-        body = body.replace(originSubstring, finalSubstring);
+        replacedBodySubstrings.put(originSubstring, finalSubstring);
     }
 
     public void fixPrimaryKeyValuesInBody() {
+        body = fixPrimaryKeyValuesInBody(body);
+    }
+
+    public static String fixPrimaryKeyValuesInBody(String strBody) {
         JSONObject currentBodyJson;
 
-        if (body == null || body.length() == 0) return;
+        if (strBody == null || strBody.length() == 0) return strBody;
 
         try {
-            currentBodyJson = new JSONObject(this.body);
+            currentBodyJson = new JSONObject(strBody);
         } catch (Exception ignored) {
-            return;
+            return strBody;
         }
 
         for (String keyStr : currentBodyJson.keySet()) {
@@ -106,7 +142,7 @@ public class MutableHttpRequest extends HttpServletRequestWrapper {
             }
         }
 
-        body = currentBodyJson.toString();
+        return currentBodyJson.toString();
     }
 
     public void setExistingEntitiesList(List<String> entities)
@@ -172,8 +208,23 @@ public class MutableHttpRequest extends HttpServletRequestWrapper {
         }
 
         // filter PrimaryKey
-        Pattern patternFilterPk = Pattern.compile("%24filter=[^\\%]*__PrimaryKey[^\\%\\,]*\\+[0-9a-f\\-]{36}", Pattern.CASE_INSENSITIVE);
+        Pattern patternFilterPk = Pattern.compile("%24filter=[^\\%]*__PrimaryKey[^\\%\\,]*\\+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", Pattern.CASE_INSENSITIVE);
         Matcher matcherFilterPk = patternFilterPk.matcher(modifiedQueryString);
+
+        while(matcherFilterPk.find())
+        {
+            String foundPkFilter = matcherFilterPk.group();
+            int foundPkFilterLength = foundPkFilter.length();
+
+            String fixedPkFiler = foundPkFilter.substring(0, foundPkFilterLength - 36) +
+                    "'" + foundPkFilter.substring(foundPkFilterLength - 36, foundPkFilterLength) + "'";
+
+            modifiedQueryString = modifiedQueryString.replace(foundPkFilter, fixedPkFiler);
+        }
+
+        // PrimaryKey в прямом запросе
+        patternFilterPk = Pattern.compile("http:\\/\\/.*\\/FlexberryGISService\\/odata\\/.*\\([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", Pattern.CASE_INSENSITIVE);
+        matcherFilterPk = patternFilterPk.matcher(modifiedQueryString);
 
         while(matcherFilterPk.find())
         {
@@ -194,7 +245,7 @@ public class MutableHttpRequest extends HttpServletRequestWrapper {
         return modifiedQueryString;
     }
 
-    private String convertGISJsonValuesToString(String body) {
+    public static String convertGISJsonValuesToString(String body) {
         if (body.equals("")) return body;
         
         // Olingo не понимает тип JSON, только строку. Поэтому нужно преобразовать значение полей с геоданными в строку.
@@ -215,5 +266,46 @@ public class MutableHttpRequest extends HttpServletRequestWrapper {
         }
 
         return convertedBody;
+    }
+
+    public static String getBatchBoundary(HttpServletRequest request) {
+        String contentType =  request.getContentType();
+        int indexBoundary = contentType.indexOf("boundary=");
+
+        if (indexBoundary >= 0) {
+            String[] arr = contentType.substring(indexBoundary).split("[=;]");
+
+            if (arr.length > 1) return arr[1];
+        }
+
+        return null;
+    }
+
+    public void ApplyChangesForRequest() {
+        if (this.isBatchRequest) {
+            for (BatchRequestPart batchRequestPart : batchRequest.parts) {
+                for (BatchSubRequest batchSubRequest : batchRequestPart.requests) {
+                    // body
+                    batchSubRequest.bodyPart = convertGISJsonValuesToString(batchSubRequest.bodyPart);
+
+                    for (Map.Entry<String, String> entry : replacedBodySubstrings.entrySet()) {
+                        batchSubRequest.bodyPart = batchSubRequest.bodyPart.replace(entry.getKey(), entry.getValue());
+                    }
+
+                    batchSubRequest.bodyPart = fixPrimaryKeyValuesInBody(batchSubRequest.bodyPart);
+
+                    // query
+                    batchSubRequest.queryPart = modifyQueryString(batchSubRequest.queryPart);
+                }
+            }
+        } else {
+            body = convertGISJsonValuesToString(body);
+
+            for (Map.Entry<String, String> entry : replacedBodySubstrings.entrySet()) {
+                body = body.replace(entry.getKey(), entry.getValue());
+            }
+
+            fixPrimaryKeyValuesInBody();
+        }
     }
 }

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpRequest.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/MutableHttpRequest.java
@@ -296,6 +296,17 @@ public class MutableHttpRequest extends HttpServletRequestWrapper {
 
                     // query
                     batchSubRequest.queryPart = modifyQueryString(batchSubRequest.queryPart);
+
+                    // headers
+                    for (String excessHeader : excessHeaders) {
+                        batchSubRequest.headers = BatchRequest.removeHeader(batchSubRequest.headers, excessHeader);
+                        batchSubRequest.queryHeaders = BatchRequest.removeHeader(batchSubRequest.queryHeaders, excessHeader);
+                    }
+                }
+
+                // headers
+                for (String excessHeader : excessHeaders) {
+                    batchRequestPart.headers = BatchRequest.removeHeader(batchRequestPart.headers, excessHeader);
                 }
             }
         } else {

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/Servlet.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/service/Servlet.java
@@ -75,7 +75,7 @@ public class Servlet extends HttpServlet {
 
       final JPAODataCRUDHandler handler = new JPAODataCRUDHandler(serviceContext);
       handler.getJPAODataRequestContext().setEntityManager(entityManager);
-	    handler.getJPAODataRequestContext().setCUDRequestHandler(new JPAExampleCUDRequestHandler());
+	  handler.getJPAODataRequestContext().setCUDRequestHandler(new JPAExampleCUDRequestHandler());
       handler.process(req, resp);
     } catch (RuntimeException | ODataException e) {
       throw new ServletException(e);

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/UUIDToStringConverter.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/UUIDToStringConverter.java
@@ -1,0 +1,35 @@
+package Flexberry.GIS.utils;
+
+import org.eclipse.persistence.internal.helper.DatabaseField;
+import org.eclipse.persistence.mappings.DatabaseMapping;
+import org.eclipse.persistence.sessions.Session;
+
+import java.sql.Types;
+import java.util.UUID;
+
+public class UUIDToStringConverter implements org.eclipse.persistence.mappings.converters.Converter {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Object convertObjectValueToDataValue(Object objectValue, Session session) {
+        return objectValue == null ? null : UUID.fromString(String.valueOf(objectValue));
+    }
+
+    @Override
+    public Object convertDataValueToObjectValue(Object dataValue, Session session) {
+        return dataValue == null ? null : dataValue.toString();
+    }
+
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    @Override
+    public void initialize(DatabaseMapping mapping, Session session) {
+        DatabaseField field = mapping.getField();
+        field.setSqlType(Types.OTHER);
+        field.setTypeName("java.util.UUID");
+        field.setColumnDefinition("UUID");
+    }
+}

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchRequest.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchRequest.java
@@ -1,0 +1,201 @@
+package Flexberry.GIS.utils.batch;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BatchRequest {
+    public String url;
+    public String body;
+    public String boundaryId;
+    public List<BatchRequestPart> parts;
+
+    public BatchRequest(String url, String body, String boundaryId) throws ParseException {
+        this.url = url;
+        this.body = body;
+        this.boundaryId = boundaryId;
+
+        parseBody();
+    }
+
+    private void parseBody() throws ParseException {
+        parts = new ArrayList<>();
+        String[] lines = body.split(System.lineSeparator());
+
+        for (int i = 0; i < lines.length; i++) lines[i]= lines[i].trim();
+
+        String boundaryCheckValue = "--" + boundaryId + "--";
+        Integer endIndex = SeekLinesToValue(0, lines, boundaryCheckValue);
+
+        // Если не нашли конца запроса, то вернем ошибку.
+        if (endIndex >= lines.length) throw getParseException(boundaryCheckValue, endIndex, 0);
+
+        Integer currentIndex = SeekEmptyLines(0, lines);
+
+        while (currentIndex < endIndex) {
+            boundaryCheckValue = "--" + boundaryId;
+
+            // Каждый блок должен начинаться с --ID запроса
+            if (!lines[currentIndex].equals(boundaryCheckValue)) throw getParseException(boundaryCheckValue, currentIndex, 0);
+
+            currentIndex++;
+            BatchRequestPart batchRequestPart = new BatchRequestPart(boundaryId);
+
+            // Заголовки.
+            batchRequestPart.headers = getHeaders(currentIndex, lines, endIndex);
+            currentIndex += batchRequestPart.headers.size();
+
+            for (Map.Entry<String, String> entry : batchRequestPart.headers.entrySet()) {
+                if (entry.getKey().equals("Content-Type")) batchRequestPart.ContentType = entry.getValue();
+            }
+
+            currentIndex = SeekEmptyLines(currentIndex, lines);
+
+            // Changeset.
+            if (batchRequestPart.ContentType.startsWith("multipart/mixed;boundary=")) {
+                String changeSetId = batchRequestPart.ContentType.substring("multipart/mixed;boundary=".length());
+                String changeSetIdCheckValue = "--" + changeSetId + "--";
+                Integer changeSetEndIndex = SeekLinesToValue(currentIndex, lines, changeSetIdCheckValue);
+
+                // Если не нашли конца Changeset, то вернем ошибку.
+                if (changeSetEndIndex >= endIndex) throw getParseException(changeSetIdCheckValue, changeSetEndIndex, 0);
+
+                batchRequestPart.isChangeSet = true;
+                batchRequestPart.changeSetId = changeSetId;
+                changeSetIdCheckValue = "--" + changeSetId;
+
+                // Каждый блок должен начинаться с --Changeset.
+                if (!lines[currentIndex].equals(changeSetIdCheckValue)) throw getParseException(changeSetIdCheckValue, currentIndex, 0);
+
+                // Пока встречаются --Changeset.
+                while (currentIndex < changeSetEndIndex && lines[currentIndex].equals(changeSetIdCheckValue)) {
+                    currentIndex++;
+                    BatchSubRequest batchSubRequest = new BatchSubRequest();
+
+                    // Заголовки.
+                    batchSubRequest.headers = getHeaders(currentIndex, lines, changeSetEndIndex);
+                    currentIndex += batchSubRequest.headers.size();
+
+                    currentIndex = SeekEmptyLines(currentIndex, lines);
+
+                    // Строка запроса.
+                    batchSubRequest.queryPart = lines[currentIndex];
+                    currentIndex = SeekEmptyLines(currentIndex + 1, lines);
+
+                    // Заголовки.
+                    batchSubRequest.queryHeaders = getHeaders(currentIndex, lines, changeSetEndIndex);
+                    currentIndex += batchSubRequest.queryHeaders.size();
+                    currentIndex = SeekEmptyLines(currentIndex, lines);
+
+                    // Тело запроса.
+                    StringBuilder bodyBuilder = new StringBuilder();
+
+                    while (currentIndex < changeSetEndIndex && !lines[currentIndex].startsWith("--")) {
+                        if (lines[currentIndex].length() > 0) {
+                            bodyBuilder.append(lines[currentIndex]);
+                        }
+
+                        currentIndex++;
+                    }
+
+                    batchSubRequest.bodyPart = bodyBuilder.toString();
+                    batchRequestPart.requests.add(batchSubRequest);
+                }
+
+                // Пропускаем --Changeset--.
+                currentIndex = SeekEmptyLines(currentIndex + 1, lines);
+            } else {
+                // Не Changeset запрос.
+                BatchSubRequest batchSubRequest = new BatchSubRequest();
+
+                // Строка запроса.
+                batchSubRequest.queryPart = lines[currentIndex];
+                currentIndex = SeekEmptyLines(currentIndex + 1, lines);
+
+                // Заголовки.
+                batchSubRequest.queryHeaders = getHeaders(currentIndex, lines, endIndex);
+                currentIndex += batchSubRequest.queryHeaders.size();
+                currentIndex = SeekEmptyLines(currentIndex, lines);
+
+                // Тело запроса.
+                StringBuilder bodyBuilder = new StringBuilder();
+
+                while (currentIndex < endIndex && !lines[currentIndex].startsWith("--")) {
+                    if (lines[currentIndex].length() > 0) {
+                        bodyBuilder.append(lines[currentIndex]);
+                    }
+
+                    currentIndex++;
+                }
+
+                batchSubRequest.bodyPart = bodyBuilder.toString();
+                batchRequestPart.requests.add(batchSubRequest);
+            }
+
+            parts.add(batchRequestPart);
+        }
+    }
+
+    public static int SeekEmptyLines(Integer currentIndex, String[] lines) {
+        Integer ind = currentIndex;
+
+        while(ind < lines.length && lines[ind].length() == 0) ind++;
+
+        return ind;
+    }
+
+    public static int SeekLinesToValue(Integer currentIndex, String[] lines, String value) {
+        Integer ind = currentIndex;
+
+        while(ind < lines.length && !lines[ind].equals(value)) ind++;
+
+        return ind;
+    }
+
+    public static HashMap<String, String> getHeaders(Integer startIndex, String[] lines, Integer endIndex) throws ParseException {
+        HashMap<String, String> headers = new HashMap<>();
+        Integer currentIndex = startIndex;
+
+        while (currentIndex <= endIndex && lines[currentIndex].length() > 0) {
+            String header = lines[currentIndex];
+            Integer nameLength = header.indexOf(":");
+
+            // Проверка заголовка.
+            if (nameLength <= 0) throw getParseException(":", currentIndex, header.length());
+
+            String headerName = header.substring(0, nameLength);
+            String headerValue = header.substring(nameLength + 1).trim();
+
+            headers.put(headerName, headerValue);
+            currentIndex++;
+        }
+
+        return headers;
+    }
+
+    public static ParseException getParseException(String str, Integer lineNumber, Integer position) {
+        return new ParseException("Ожидается значение '" + str + "' в строке " + lineNumber.toString()
+                + " на позиции " + position.toString(), lineNumber);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (BatchRequestPart batchRequestPart : parts) {
+            sb.append(System.lineSeparator());
+            sb.append(System.lineSeparator());
+            sb.append("--" + boundaryId);
+            sb.append(System.lineSeparator());
+            sb.append(batchRequestPart.toString());
+        }
+
+        sb.append(System.lineSeparator());
+        sb.append(System.lineSeparator());
+        sb.append("--" + boundaryId + "--");
+
+        return sb.toString();
+    }
+}

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchRequest.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchRequest.java
@@ -175,6 +175,20 @@ public class BatchRequest {
         return headers;
     }
 
+    public static HashMap<String, String> removeHeader(HashMap<String, String> headers, String removeValue) {
+        String keyValue = null;
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(removeValue)) {
+                keyValue = entry.getKey();
+            }
+        }
+
+        if (keyValue != null) headers.remove(keyValue);
+
+        return headers;
+    }
+
     public static ParseException getParseException(String str, Integer lineNumber, Integer position) {
         return new ParseException("Ожидается значение '" + str + "' в строке " + lineNumber.toString()
                 + " на позиции " + position.toString(), lineNumber);

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchRequestPart.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchRequestPart.java
@@ -1,0 +1,47 @@
+package Flexberry.GIS.utils.batch;
+
+import java.util.*;
+
+public class BatchRequestPart {
+    public String boundaryId;
+    public boolean isChangeSet = false;
+    public String changeSetId = "";
+    public HashMap<String, String> headers = new HashMap<>();
+    public ArrayList<BatchSubRequest> requests = new ArrayList<>();
+
+    public String ContentType = "";
+
+    public BatchRequestPart(String boundaryId) {
+        this.boundaryId = boundaryId;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            sb.append(key + ": " + value + System.lineSeparator());
+        }
+
+        sb.append(System.lineSeparator());
+
+        if (isChangeSet) {
+            for (BatchSubRequest batchSubRequest : requests) {
+                sb.append("--" + changeSetId);
+                sb.append(System.lineSeparator());
+                sb.append(batchSubRequest.toString());
+            }
+
+            sb.append(System.lineSeparator());
+            sb.append("--" + changeSetId + "--");
+            sb.append(System.lineSeparator());
+        } else {
+            sb.append(requests.get(0).toString());
+        }
+
+        return sb.toString();
+    }
+}

--- a/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchSubRequest.java
+++ b/JavaGISOdataBackend/src/main/java/Flexberry.GIS/utils/batch/BatchSubRequest.java
@@ -1,0 +1,46 @@
+package Flexberry.GIS.utils.batch;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BatchSubRequest {
+    public HashMap<String, String> headers = new HashMap<>();
+    public String queryPart = "";
+    public HashMap<String, String> queryHeaders = new HashMap<>();
+    public String bodyPart = "";
+
+    public BatchSubRequest() {
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            sb.append(key + ": " + value + System.lineSeparator());
+        }
+
+        if (headers.size() > 0) sb.append(System.lineSeparator());
+
+        sb.append(queryPart);
+        sb.append(System.lineSeparator());
+
+        for (Map.Entry<String, String> entry : queryHeaders.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            sb.append(key + ": " + value + System.lineSeparator());
+        }
+
+        if (bodyPart.length() > 0) {
+            sb.append(System.lineSeparator());
+            sb.append(bodyPart);
+            sb.append(System.lineSeparator());
+        }
+
+        return sb.toString();
+    }
+}

--- a/SQL/02-create-tables.sql
+++ b/SQL/02-create-tables.sql
@@ -65,6 +65,10 @@ CREATE TABLE LinkMetadata (
 
 CREATE TABLE MapObjectSetting (
  primaryKey UUID NOT NULL,
+ CreateTime TIMESTAMP(3) NULL,
+ Creator VARCHAR(255) NULL,
+ Editor VARCHAR(255) NULL,
+ EditTime TIMESTAMP(3) NULL,
  EditForm VARCHAR(255) NULL,
  ListForm VARCHAR(255) NULL,
  MultEditForm VARCHAR(255) NULL,


### PR DESCRIPTION
Так же прикручено добавление кавычек к значениям primaryKey в запросах с указанием мастера, и в $filter при запросе данных через $expand.